### PR TITLE
Fix open() call with too many arguments

### DIFF
--- a/Src/Global/Platform.c
+++ b/Src/Global/Platform.c
@@ -241,7 +241,7 @@ int CheckOpenIPCFile(char *Instance, char *Name, char *ret_Path, int DirCraeteOr
     }
     break;
     case FILENAME_CREATE_EXIST:
-        if ((fh = open(Path, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH, 0600)) < 0) {
+        if ((fh = open(Path, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH)) < 0) {
             return -1;
         }
         close(fh);


### PR DESCRIPTION
Error message issued by gcc:

~~~
error: call to ‘__open_too_many_args’ declared with attribute error:
  open can be called either with 2 or 3 arguments, not more
~~~
