### PR TITLE
resolve #10

### DIFF
--- a/Samples/ExternalProcesses/ExtProc_Esmini/CMakeLists.txt
+++ b/Samples/ExternalProcesses/ExtProc_Esmini/CMakeLists.txt
@@ -28,3 +28,9 @@ install(TARGETS ${ExtProc_TargetName}
     RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/${SampleOutputFolder}/ExtProc_Esmin
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
+if(WIN32)
+    INSTALL(DIRECTORY "${ESMINI_LIBRARY_PATH}/bin/"
+            DESTINATION ${CMAKE_INSTALL_PREFIX}/${SampleOutputFolder}/ExtProc_Esmin
+            FILES_MATCHING PATTERN "*.dll")
+ endif()
+


### PR DESCRIPTION
- copy esminiLib.dll to the ExtProc_Esmin folder when building for a Windows-based system