### PR TITLE
fix(a2l): correct LINEAR conversion inverse to divide by slope

### DIFF
--- a/Src/A2lParser/A2LConvert.c
+++ b/Src/A2lParser/A2LConvert.c
@@ -461,7 +461,7 @@ int ConvertRawToPhys(ASAP2_MODULE_DATA* Module, const char *par_ConvertName, int
             if ((par_Flags & A2L_GET_PHYS_FLAG) == A2L_GET_PHYS_FLAG) {
                 if (CheckIfFlagSetPos(CompuMethod->OptionalParameter.Flags, OPTPARAM_COMPU_METHOD_COEFFS_LINEAR)) {
                     double Value = (ConvertRawValueToDouble(par_Raw) - CompuMethod->OptionalParameter.Coeffs.b) /
-                                    CompuMethod->OptionalParameter.Coeffs.b;
+                                    CompuMethod->OptionalParameter.Coeffs.a;
                     ConvertDoubleToPhysValue(par_Raw->TargetType, Value, ret_Phys);
                     if ((par_Flags & A2L_GET_UNIT_FLAG) == A2L_GET_UNIT_FLAG) {
                         AddUnitToValue(ret_Phys, CompuMethod->Unit);


### PR DESCRIPTION
## Summary

Fixes the LINEAR (COEFFS_LINEAR) conversion in A2LConvert.c: ConvertRawToPhys divided by the offset `b` instead of the slope `a` when computing the inverse.

Per the ASAP2 spec the conversion is `phys = a * raw + b`, so the inverse must be `phys = (raw - b) / a`. The old code produced `(raw - b) / b`, which is wrong for any `a != b` and divides by zero when `b == 0`.

## Change

Src/A2lParser/A2LConvert.c (ConvertRawToPhys, LINEAR case):

`diff
 double Value = (ConvertRawValueToDouble(par_Raw) - CompuMethod->OptionalParameter.Coeffs.b) /
-                CompuMethod->OptionalParameter.Coeffs.b;
+                CompuMethod->OptionalParameter.Coeffs.a;
`

This makes the raw-to-phys direction consistent with the phys-to-raw direction already used in ConvertPhysToRaw.

## Verification

Round-trip check: for COEFFS_LINEAR a=2, b=10, raw=100 now decodes to phys=210 and encodes back to raw=100.