### PR TITLE
fix: A2L axis-point symbol resolution and matrix dimensions

### DIFF
--- a/Src/A2lParser/A2LParser.c
+++ b/Src/A2lParser/A2LParser.c
@@ -864,8 +864,8 @@ int ParseCharacteristicMatrixDim (struct ASAP2_PARSER_STRUCT *Parser, void* Data
     CHECK_SET_FLAG_BIT_POS (Characteristic->OptionalParameter.Flags, 
                         OPTPARAM_CHARACTERISTIC_MATRIX_DIM);
     Characteristic->OptionalParameter.MatrixDim.x = ReadIntFromFile (Parser);
-    Characteristic->OptionalParameter.MatrixDim.y = TryReadIntFromFile (Parser, 0);  // sometime this is missing
-    Characteristic->OptionalParameter.MatrixDim.z = TryReadIntFromFile (Parser, 0);  // sometime this is missing
+    Characteristic->OptionalParameter.MatrixDim.y = TryReadIntFromFile (Parser, 1);  // sometimes this is missing; then use 1 as default
+    Characteristic->OptionalParameter.MatrixDim.z = TryReadIntFromFile (Parser, 1);  // sometimes this is missing; then use 1 as default
     return CheckParserError (Parser);
 }
 
@@ -1087,8 +1087,8 @@ int ParseMeasurementMatrixDim (struct ASAP2_PARSER_STRUCT *Parser, void* Data, s
     CHECK_SET_FLAG_BIT_POS (Measurement->OptionalParameter.Flags,
                         OPTPARAM_MEASUREMENT_MATRIX_DIM);
     Measurement->OptionalParameter.MatrixDim.x = ReadIntFromFile (Parser);
-    Measurement->OptionalParameter.MatrixDim.y = TryReadIntFromFile (Parser, 0);  // sometime this is missing
-    Measurement->OptionalParameter.MatrixDim.z = TryReadIntFromFile (Parser, 0);  // sometime this is missing
+    Measurement->OptionalParameter.MatrixDim.y = TryReadIntFromFile (Parser, 1);  // sometimes this is missing; then use 1 as default
+    Measurement->OptionalParameter.MatrixDim.z = TryReadIntFromFile (Parser, 1);  // sometimes this is missing; then use 1 as default
     return CheckParserError (Parser);
 }
 

--- a/Src/A2lParser/A2LUpdate.c
+++ b/Src/A2lParser/A2LUpdate.c
@@ -537,7 +537,7 @@ int A2LUpdate(ASAP2_DATABASE *Database, const char *par_OutA2LFile, const char *
             for (x = 0; x < Module->AxisPtsCounter; x++) {
                 uint64_t Address = 0;
                 ASAP2_AXIS_PTS *AxisPts = Module->AxisPtss[x];
-                if (CheckIfFlagSetPos(AxisPts->OptionalParameter.Flags, OPTPARAM_CHARACTERISTIC_SYMBOL_LINK)) {
+                if (CheckIfFlagSetPos(AxisPts->OptionalParameter.Flags, OPTPARAM_AXIS_PTS_SYMBOL_LINK)) {
                     Address = GetAddressByA2LLabel(SymFile, pappldata, AxisPts->OptionalParameter.SymbolLink, &NotUpdatedLabelFile);
                 } else {
                     if (AxisPts->OptionalParameter.IfDataCanapeExtCount == 0) {


### PR DESCRIPTION
- Correct axis-point SYMBOL_LINK flag handling during address updates.
- Default omitted MEASUREMENT matrix Y/Z dimensions to 1 instead of 0.

Fixes #68